### PR TITLE
If a file compiles with errors, stop compiling and return the error to grunt.

### DIFF
--- a/tasks/wisp.js
+++ b/tasks/wisp.js
@@ -52,6 +52,11 @@ module.exports = function (grunt) {
             mkdirp.sync(destPath);
             var destFileName = fileName.split(".")[0];//拡張子を除く
             exec('cat ' + file + '| wisp > ' + destPath + destFileName + ".js", function (err, stdout, stderr) {
+                if (err) {
+                    err.message = 'Error compiling ' + file + ': ' + err.message;
+                    done(err);
+                    return;
+                }
                 grunt.log.writeln('File ' + destPath + destFileName + '.js created.');
                 compile(srcBaseDir, path, files, done);
             });


### PR DESCRIPTION
Without this patch, the resulting JS file is empty and you aren't warned of any errors.
